### PR TITLE
PSR-4 namespaces

### DIFF
--- a/HardwareProfileCloud.php
+++ b/HardwareProfileCloud.php
@@ -21,10 +21,7 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-
 namespace fiftyone\pipeline\devicedetection;
-
-require("vendor/autoload.php");
 
 use fiftyone\pipeline\cloudrequestengine\CloudEngine;
 use fiftyone\pipeline\cloudrequestengine\CloudRequestEngine;

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,12 @@
       "HardwareProfileCloud.php"
     ]
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/",
+      "Examples\\": "examples/"
+    }
+  },
   "require": {
     "51degrees/fiftyone.pipeline.core": "4.*",
     "51degrees/fiftyone.pipeline.engines": "4.*",

--- a/examples/cloud/exampleUtils.php
+++ b/examples/cloud/exampleUtils.php
@@ -21,8 +21,9 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-require_once(__DIR__ . "/../../vendor/autoload.php");
+namespace Examples\Cloud;
 
+use Exception;
 use fiftyone\pipeline\core\Logger;
 
 class ExampleUtils

--- a/examples/cloud/failureToMatch.php
+++ b/examples/cloud/failureToMatch.php
@@ -49,9 +49,9 @@
  * ```
 */
 
-// First we include the deviceDetectionPipelineBuilder
+namespace Examples\Cloud;
 
-require(__DIR__ . "/../../vendor/autoload.php");
+// First we include the deviceDetectionPipelineBuilder
 
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 

--- a/examples/cloud/gettingStartedConsole.php
+++ b/examples/cloud/gettingStartedConsole.php
@@ -32,10 +32,9 @@
  *
  * Required Composer Dependencies:
  * - 51degrees/fiftyone.devicedetection
- */ 
+ */
 
-require_once(__DIR__ . "/exampleUtils.php");
-require_once(__DIR__ . "/../../vendor/autoload.php");
+namespace Examples\Cloud;
 
 use fiftyone\pipeline\core\PipelineBuilder;
 use fiftyone\pipeline\core\Logger;

--- a/examples/cloud/gettingStartedWeb.php
+++ b/examples/cloud/gettingStartedWeb.php
@@ -75,8 +75,8 @@
  *
  * ## Class
  */
-require_once(__DIR__ . "/exampleUtils.php");
-require_once(__DIR__ . "/../../vendor/autoload.php");
+
+namespace Examples\Cloud;
 
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 use fiftyone\pipeline\core\Logger;

--- a/examples/cloud/metadataConsole.php
+++ b/examples/cloud/metadataConsole.php
@@ -47,8 +47,7 @@
  * - 51degrees/fiftyone.devicedetection
  */
 
-require_once(__DIR__ . "/exampleUtils.php");
-require_once(__DIR__ . "/../../vendor/autoload.php");
+namespace Examples\Cloud;
 
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 use fiftyone\pipeline\core\PipelineBuilder;

--- a/examples/cloud/nativeModelLookupConsole.php
+++ b/examples/cloud/nativeModelLookupConsole.php
@@ -39,8 +39,7 @@
  * - 51degrees/fiftyone.devicedetection
  */
 
-require_once(__DIR__ . "/exampleUtils.php");
-require_once(__DIR__ . "/../../vendor/autoload.php");
+namespace Examples\Cloud;
 
 use fiftyone\pipeline\cloudrequestengine\CloudRequestEngine;
 use fiftyone\pipeline\core\PipelineBuilder;

--- a/examples/cloud/static/page.php
+++ b/examples/cloud/static/page.php
@@ -20,6 +20,8 @@
  * in the end user terms of the application under an appropriate heading, 
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
+
+use Examples\Cloud\ExampleUtils;
 ?>
 <head>
     <title>Web Integration Example</title>

--- a/examples/cloud/tacLookupConsole.php
+++ b/examples/cloud/tacLookupConsole.php
@@ -36,8 +36,7 @@
  * - 51degrees/fiftyone.devicedetection
  */
 
-require_once(__DIR__ . "/exampleUtils.php");
-require_once(__DIR__ . "/../../vendor/autoload.php");
+namespace Examples\Cloud;
 
 use fiftyone\pipeline\cloudrequestengine\CloudRequestEngine;
 use fiftyone\pipeline\core\PipelineBuilder;

--- a/examples/cloud/userAgentClientHints-Web.php
+++ b/examples/cloud/userAgentClientHints-Web.php
@@ -53,9 +53,9 @@
  *
  */
 
-// First we include the deviceDetectionPipelineBuilder
+namespace Examples\Cloud;
 
-require(__DIR__ . "/../../vendor/autoload.php");
+// First we include the deviceDetectionPipelineBuilder
 
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 use fiftyone\pipeline\core\Utils;

--- a/tests/UACHCloudTests.php
+++ b/tests/UACHCloudTests.php
@@ -21,11 +21,12 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-require(__DIR__ . "/../vendor/autoload.php");
-require_once(__DIR__ . '/classes/process.php');
-require_once(__DIR__ . '/classes/constants.php');
+namespace Tests;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
+use Tests\Classes\Constants;
+use Tests\Classes\Process;
 
 /**
  * @requires OS Linux
@@ -38,25 +39,25 @@ class UACHCloudTests extends TestCase{
     {
         // start server
         self::$process = new Process('php -S localhost:3000 examples/cloud/userAgentClientHints-Web.php');
-        self::$process->start();      
+        self::$process->start();
         if (self::$process->status()){
-			shell_exec("lsof -i tcp:3000 1>/dev/null 2>&1" );
+            shell_exec("lsof -i tcp:3000 1>/dev/null 2>&1" );
             echo "User Agent Client Hints Web example has started running.\n";
         }else{
             throw new Exception("Could not start the User Agent Client Hints-Cloud Web example. \n");
-        } 
+        }
     }
 
     public static function tearDownAfterClass() : void
     {
         // stop server
         if(self::$process->stop()) {
-            echo "\nProcess stopped for User Agent Client Hints-Cloud Web example. \n";        
-        }          
+            echo "\nProcess stopped for User Agent Client Hints-Cloud Web example. \n";
+        }
     }
-            
+
     // Data Provider for testAcceptCH
-	public function provider_testAcceptCH()
+    public static function provider_testAcceptCH()
     {
         $superKey = self::getEnvVar(Constants::RESOURCE_ENV_VAR);
         $platformKey = self::getEnvVar(Constants::PLATFORM_ENV_VAR);
@@ -72,50 +73,50 @@ class UACHCloudTests extends TestCase{
 
         // Get all combinations of keys and uas and determine 
         // which values we are expecting to see in Accept-CH.
-                                         
+
         $testParameters = array();
         foreach ($resourceKeys as $key) {
             foreach ($userAgents as $ua) {
-                                    
+
                 if ($ua == Constants::CHROME_UA || $ua == Constants::EDGE_UA) {
                     if ($key == $browserKey)
                     {
-                        $testParameters[] = array($ua, $key, Constants::BROWSER_ACCEPT_CH);                       
+                        $testParameters[] = array($ua, $key, Constants::BROWSER_ACCEPT_CH);
                     }
                     else if ($key == $hardwareKey)
                     {
-                        $testParameters[] = array($ua, $key, Constants::HARDWARE_ACCEPT_CH);                       
+                        $testParameters[] = array($ua, $key, Constants::HARDWARE_ACCEPT_CH);
                     }
                     else if ($key == $platformKey)
-                    {                    
-                        $testParameters[] = array($ua, $key, Constants::PLATFORM_ACCEPT_CH);                        
+                    {
+                        $testParameters[] = array($ua, $key, Constants::PLATFORM_ACCEPT_CH);
                     }
                     else if ($key == $superKey)
                     {
-                        $testParameters[] = array($ua, $key, Constants::SUPER_ACCEPT_CH);                       
+                        $testParameters[] = array($ua, $key, Constants::SUPER_ACCEPT_CH);
                     }
                     else {
-                        $testParameters[] = array($ua, $key, Constants::EMPTY_ACCEPT_CH);                     
-                    }                    
+                        $testParameters[] = array($ua, $key, Constants::EMPTY_ACCEPT_CH);
+                    }
                 }
                 else {
                     $testParameters[] = array($ua, $key, Constants::EMPTY_ACCEPT_CH);
-                }             
+                }
             }
         }
-        
+
         return $testParameters;
-               
+
     }
 
     // Tests response header value to set in Accept-CH
     // response header.
     /**
      * @dataProvider provider_testAcceptCH
-	 * @requires PHP >= 7.2
+     * @requires PHP >= 7.2
      */
     public function testAcceptCH($userAgent, $resourceKey, $expectedValue)
-    {    
+    {
         $requestHeaders = Constants::UA_HEADER . $userAgent . '\r\n' ;
 
         $context = stream_context_create(array(
@@ -124,40 +125,40 @@ class UACHCloudTests extends TestCase{
                 'header' =>  $requestHeaders
             )
         ));
-      
+
         $data = @file_get_contents(Constants::URL . '?RESOURCEKEY=' . $resourceKey, false, $context);
         $responseHeaders = self::parseHeaders($http_response_header);
 
         $this->assertEquals(200, $responseHeaders['response_code']);
-        
-        if(is_null($expectedValue) || count($expectedValue) == 0) 
-        {      
+
+        if(is_null($expectedValue) || count($expectedValue) == 0)
+        {
             $this->assertFalse(isset($responseHeaders['Accept-CH']));
-        } 
-        else 
-        {   
-            $this->assertTrue(isset($responseHeaders['Accept-CH']));           
-            
+        }
+        else
+        {
+            $this->assertTrue(isset($responseHeaders['Accept-CH']));
+
             // We don't require the expected list of values to match exactly, as the headers 
             // used by detection change over time. However, we do make sure that the most 
             // critical ones are present in Accept-CH.
             $actualValue = explode(',', $responseHeaders['Accept-CH']);
-            foreach($expectedValue as $e) {           
+            foreach($expectedValue as $e) {
                 $lowerCasedExpectedValue = strtolower($e);
                 $lowerCasedActualArray = array_map('strtolower', array_map('trim', $actualValue));
-                $this->assertTrue(in_array($lowerCasedExpectedValue, $lowerCasedActualArray));           
+                $this->assertTrue(in_array($lowerCasedExpectedValue, $lowerCasedActualArray));
             }
-        }                          
+        }
     }
 
     /**
      *  Gets environment variable value.
      */
     private static function getEnvVar($name) {
-    	$resourceKey = getEnv($name);
+        $resourceKey = getEnv($name);
         if (!isset($resourceKey) || empty($resourceKey)) {
             throw new Exception("Environment variable " . $name . " needs to be set to run Cloud tests.");
-        }     
+        }
         return $resourceKey;
     }
 

--- a/tests/UACHCloudTests_PHP5.php
+++ b/tests/UACHCloudTests_PHP5.php
@@ -21,11 +21,12 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-require(__DIR__ . "/../vendor/autoload.php");
-require_once(__DIR__ . '/classes/process.php');
-require_once(__DIR__ . '/classes/constants.php');
+namespace Tests;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
+use Tests\Classes\Constants;
+use Tests\Classes\Process;
 
 /**
  * @requires OS Linux
@@ -38,27 +39,27 @@ class UACHCloudTests_PHP5 extends TestCase{
     {
         // start server
         self::$process = new Process('php -S localhost:3000 examples/cloud/userAgentClientHints-Web.php');
-        self::$process->start();      
+        self::$process->start();
         if (self::$process->status()){
-			shell_exec("lsof -i tcp:3000 1>/dev/null 2>&1" );
+            shell_exec("lsof -i tcp:3000 1>/dev/null 2>&1" );
             echo "User Agent Client Hints Web example has started running.\n";
         }else{
             throw new Exception("Could not start the User Agent Client Hints-Cloud Web example. \n");
         }
-        return;		
+        return;
     }
 
     public static function tearDownAfterClass()
     {
         // stop server
         if(self::$process->stop()) {
-            echo "\nProcess stopped for User Agent Client Hints-Cloud Web example. \n";        
+            echo "\nProcess stopped for User Agent Client Hints-Cloud Web example. \n";
         }
-        return;		
+        return;
     }
-            
+
     // Data Provider for testAcceptCH
-	public function provider_testAcceptCH()
+    public function provider_testAcceptCH()
     {
         $superKey = self::getEnvVar(Constants::RESOURCE_ENV_VAR);
         $platformKey = self::getEnvVar(Constants::PLATFORM_ENV_VAR);
@@ -74,50 +75,50 @@ class UACHCloudTests_PHP5 extends TestCase{
 
         // Get all combinations of keys and uas and determine 
         // which values we are expecting to see in Accept-CH.
-                                         
+
         $testParameters = array();
         foreach ($resourceKeys as $key) {
             foreach ($userAgents as $ua) {
-                                    
+
                 if ($ua == Constants::CHROME_UA || $ua == Constants::EDGE_UA) {
                     if ($key == $browserKey)
                     {
-                        $testParameters[] = array($ua, $key, Constants::BROWSER_ACCEPT_CH);                       
+                        $testParameters[] = array($ua, $key, Constants::BROWSER_ACCEPT_CH);
                     }
                     else if ($key == $hardwareKey)
                     {
-                        $testParameters[] = array($ua, $key, Constants::HARDWARE_ACCEPT_CH);                       
+                        $testParameters[] = array($ua, $key, Constants::HARDWARE_ACCEPT_CH);
                     }
                     else if ($key == $platformKey)
-                    {                    
-                        $testParameters[] = array($ua, $key, Constants::PLATFORM_ACCEPT_CH);                        
+                    {
+                        $testParameters[] = array($ua, $key, Constants::PLATFORM_ACCEPT_CH);
                     }
                     else if ($key == $superKey)
                     {
-                        $testParameters[] = array($ua, $key, Constants::SUPER_ACCEPT_CH);                       
+                        $testParameters[] = array($ua, $key, Constants::SUPER_ACCEPT_CH);
                     }
                     else {
-                        $testParameters[] = array($ua, $key, Constants::EMPTY_ACCEPT_CH);                     
-                    }                    
+                        $testParameters[] = array($ua, $key, Constants::EMPTY_ACCEPT_CH);
+                    }
                 }
                 else {
                     $testParameters[] = array($ua, $key, Constants::EMPTY_ACCEPT_CH);
-                }             
+                }
             }
         }
-        
+
         return $testParameters;
-               
+
     }
 
     // Tests response header value to set in Accept-CH
     // response header.
     /**
      * @dataProvider provider_testAcceptCH
-	 * @requires PHP >= 7.2
+     * @requires PHP >= 7.2
      */
     public function testAcceptCH($userAgent, $resourceKey, $expectedValue)
-    {    
+    {
         $requestHeaders = Constants::UA_HEADER . $userAgent . '\r\n' ;
 
         $context = stream_context_create(array(
@@ -126,40 +127,40 @@ class UACHCloudTests_PHP5 extends TestCase{
                 'header' =>  $requestHeaders
             )
         ));
-      
+
         $data = @file_get_contents(Constants::URL . '?RESOURCEKEY=' . $resourceKey, false, $context);
         $responseHeaders = self::parseHeaders($http_response_header);
 
         $this->assertEquals(200, $responseHeaders['response_code']);
-        
-        if(is_null($expectedValue) || count($expectedValue) == 0) 
-        {      
+
+        if(is_null($expectedValue) || count($expectedValue) == 0)
+        {
             $this->assertFalse(isset($responseHeaders['Accept-CH']));
-        } 
-        else 
-        {   
+        }
+        else
+        {
             $this->assertTrue(isset($responseHeaders['Accept-CH']));
-       
+
             // We don't require the expected list of values to match exactly, as the headers 
             // used by detection change over time. However, we do make sure that the most 
             // critical ones are present in Accept-CH.
             $actualValue = explode(',', $responseHeaders['Accept-CH']);
-            foreach($expectedValue as $e) {           
+            foreach($expectedValue as $e) {
                 $lowerCasedExpectedValue = strtolower($e);
                 $lowerCasedActualArray = array_map('strtolower', array_map('trim', $actualValue));
-                $this->assertTrue(in_array($lowerCasedExpectedValue, $lowerCasedActualArray));           
+                $this->assertTrue(in_array($lowerCasedExpectedValue, $lowerCasedActualArray));
             }
-        }                          
+        }
     }
 
     /**
      *  Gets environment variable value.
      */
     private static function getEnvVar($name) {
-    	$resourceKey = getEnv($name);
+        $resourceKey = getEnv($name);
         if (!isset($resourceKey) || empty($resourceKey)) {
             throw new Exception("Environment variable " . $name . " needs to be set to run Cloud tests.");
-        }     
+        }
         return $resourceKey;
     }
 

--- a/tests/classes/constants.php
+++ b/tests/classes/constants.php
@@ -21,6 +21,8 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+namespace Tests\Classes;
+
 class Constants {
 
     const RESOURCE_ENV_VAR = "RESOURCEKEY";

--- a/tests/classes/process.php
+++ b/tests/classes/process.php
@@ -20,7 +20,8 @@
  * in the end user terms of the application under an appropriate heading, 
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
- 
+
+namespace Tests\Classes;
  
 /* 
  * Class to track external processes for Linux only.

--- a/tests/devicedetection.php
+++ b/tests/devicedetection.php
@@ -21,13 +21,13 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-
-require(__DIR__ . "/../vendor/autoload.php");
+namespace Tests;
 
 // Fake remote address for web integration
 
 $_SERVER["REMOTE_ADDR"] = "0.0.0.0";
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 

--- a/tests/examples.php
+++ b/tests/examples.php
@@ -21,19 +21,18 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-
-require(__DIR__ . "/../vendor/autoload.php");
-require(__DIR__ . "/../examples/cloud/gettingStartedConsole.php");
-require(__DIR__ . "/../examples/cloud/gettingStartedWeb.php");
-require(__DIR__ . "/../examples/cloud/tacLookupConsole.php");
-require(__DIR__ . "/../examples/cloud/nativeModelLookupConsole.php");
-require(__DIR__ . "/../examples/cloud/metadataConsole.php");
+namespace Tests;
 
 // Fake remote address for web integration
 
 $_SERVER["REMOTE_ADDR"] = "0.0.0.0";
 $_SERVER["REQUEST_URI"] = "http://localhost";
 
+use Examples\Cloud\ExampleUtils;
+use Examples\Cloud\GettingStartedConsole;
+use Examples\Cloud\MetaDataConsole;
+use Examples\Cloud\NativeModelLookupConsole;
+use Examples\Cloud\TacLookupConsole;
 use PHPUnit\Framework\TestCase;
 use fiftyone\pipeline\core\Logger;
 

--- a/tests/examplesWeb.php
+++ b/tests/examplesWeb.php
@@ -21,11 +21,12 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-require(__DIR__ . "/../vendor/autoload.php");
-require_once(__DIR__ . '/classes/process.php');
-require_once(__DIR__ . '/classes/constants.php');
+namespace Tests;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
+use Tests\Classes\Constants;
+use Tests\Classes\Process;
 
 /**
  * @requires OS Linux

--- a/tests/examplesWeb_PHP5.php
+++ b/tests/examplesWeb_PHP5.php
@@ -21,11 +21,12 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-require(__DIR__ . "/../vendor/autoload.php");
-require_once(__DIR__ . '/classes/process.php');
-require_once(__DIR__ . '/classes/constants.php');
+namespace Tests;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
+use Tests\Classes\Constants;
+use Tests\Classes\Process;
 
 /**
  * @requires OS Linux
@@ -38,25 +39,25 @@ class ExampleWebTests extends TestCase {
     {
         // start server
         self::$process = new Process('php -S localhost:3000 examples/cloud/gettingStartedWeb.php');
-        self::$process->start();      
+        self::$process->start();
         if (self::$process->status()){
-			shell_exec("lsof -i tcp:3000 1>/dev/null 2>&1" );
+            shell_exec("lsof -i tcp:3000 1>/dev/null 2>&1" );
             echo "Getting Started Web example has started running.\n";
         }else{
             throw new Exception("Could not start the Getting Started Web example. \n");
-        } 
+        }
     }
 
     public static function tearDownAfterClass()
     {
         // stop server
         if(self::$process->stop()) {
-            echo "\nProcess stopped for Getting Started Web example. \n";        
-        }          
+            echo "\nProcess stopped for Getting Started Web example. \n";
+        }
     }
 
     public function testGettingStartedWeb()
-    {    
+    {
         $requestHeaders = Constants::UA_HEADER . Constants::CHROME_UA . '\r\n' ;
 
         $context = stream_context_create(array(
@@ -65,12 +66,12 @@ class ExampleWebTests extends TestCase {
                 'header' =>  $requestHeaders
             )
         ));
-      
+
         $data = @file_get_contents(Constants::URL, false, $context);
         $responseHeaders = self::parseHeaders($http_response_header);
 
         $this->assertEquals(200, $responseHeaders['response_code']);
-        
+
     }
 
     /**


### PR DESCRIPTION
This PR fixes issue https://github.com/51Degrees/device-detection-php/issues/2.
The proposed solution of removing the `require` statement from `HardwareProfileCloud.php` works when creating a pipeline in a Laravel controller.
However, removing that statement breaks the package for package developers, and most, if not all tests fail due to autoloader class name resolution issues.
This solution adds PSR-4 autoloading in the `autoload-dev` section of `composer.json` to avoid breaking tests, and adds PSR-4 compatible namespaces to all classes used in the `examples` and `tests` directories. The `require` statement which causes the issue when used in Laravel is also removed.