### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,7 +4,7 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`

--- a/examples/cloud/classes/GettingStartedConsole.php
+++ b/examples/cloud/classes/GettingStartedConsole.php
@@ -66,7 +66,7 @@ class GettingStartedConsole
     {
         // In this example, we use the PipelineBuilder and configure it from a file.
         // For more information about builders in general see the documentation at
-        // http://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-classes-gettingstartedconsole.php&utm_term=run
         $pipeline = (new PipelineBuilder())
             ->addLogger($logger)
             ->buildFromConfig($config);
@@ -131,7 +131,7 @@ class GettingStartedConsole
 
         // Display the results of the detection, which are called
         // device properties. See the property dictionary at
-        // https://51degrees.com/developers/property-dictionary
+        // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-classes-gettingstartedconsole.php&utm_term=analyseevidence
         // for details of all available properties.
         $this->outputValue('Mobile Device', $device->ismobile, $message);
         $this->outputValue('Platform Name', $device->platformname, $message);

--- a/examples/cloud/classes/GettingStartedWeb.php
+++ b/examples/cloud/classes/GettingStartedWeb.php
@@ -136,7 +136,7 @@ class GettingStartedWeb
         // requested. So set whatever headers are required by the browser in
         // order to return the evidence needed by the pipeline.
         // More info on this can be found at
-        // https://51degrees.com/blog/user-agent-client-hints
+        // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-classes-gettingstartedweb.php&utm_term=processrequest
         Utils::setResponseHeader($flowdata);
 
         // First we make a JSON route that will be called from the client side

--- a/examples/cloud/classes/MetadataConsole.php
+++ b/examples/cloud/classes/MetadataConsole.php
@@ -58,7 +58,7 @@ class MetadataConsole
      * In this example, we use the DeviceDetectionPipelineBuilder
      * and configure it in code. For more information about
      * pipelines in general see the documentation at
-     * https://51degrees.com/documentation/4.4/_concepts__configuration__builders__index.html.
+     * https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-classes-metadataconsole.php&utm_term=run.
      *
      * @param string $resourceKey
      * @param \fiftyone\pipeline\core\Logger $logger

--- a/examples/cloud/classes/NativeModelLookupConsole.php
+++ b/examples/cloud/classes/NativeModelLookupConsole.php
@@ -67,7 +67,7 @@ class NativeModelLookupConsole
         // This example creates the pipeline and engines in code. For a demonstration
         // of how to do this using a configuration file instead, see the TacLookup example.
         // For more information about builders in general see the documentation at
-        // http://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-classes-nativemodellookupconsole.php&utm_term=run
         $cloudRequestEngineSettings = ['resourceKey' => $resourceKey];
 
         // If a cloud endpoint has been provided then set the

--- a/examples/cloud/classes/TacLookupConsole.php
+++ b/examples/cloud/classes/TacLookupConsole.php
@@ -60,7 +60,7 @@ class TacLookupConsole
         // For a demonstration of how to do this in code instead, see the
         // NativeModelLookup example.
         // For more information about builders in general see the documentation at
-        // http://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-classes-taclookupconsole.php&utm_term=run
 
         // Create the pipeline using the service provider and the configured options.
         $pipeline = (new PipelineBuilder())

--- a/examples/cloud/failureToMatch.php
+++ b/examples/cloud/failureToMatch.php
@@ -34,7 +34,7 @@
  * The resource key is used as short-hand to store the particular set of
  * properties you are interested in as well as any associated license keys
  * that entitle you to increased request limits and/or paid-for properties.
- * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com).
+ * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-failuretomatch.php&utm_term=header).
  *
  * Expected output:
  *
@@ -57,7 +57,7 @@ use fiftyone\pipeline\core\Logger;
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 use fiftyone\pipeline\devicedetection\examples\cloud\classes\ExampleUtils;
 
-// We then create a pipeline with the builder. Create your own resource key for free at https://configure.51degrees.com.
+// We then create a pipeline with the builder. Create your own resource key for free at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-failuretomatch.php&utm_term=top.
 
 // Check if there is a resource key in the environment variable and use
 // it if there is one. You will need to switch this for your own resource key.
@@ -72,7 +72,7 @@ if (empty($resourceKey)) {
     $message = 'No resource key specified in the environment variable or query parameter ';
     $message .= "'" . ExampleUtils::RESOURCE_KEY_ENV_VAR . "'." . PHP_EOL;
     $message .= 'Create a resource key with the properties required by this example';
-    $message .= 'at https://configure.51degrees.com' . '<br/>';
+    $message .= 'at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-failuretomatch.php&utm_term=resource-key-required' . '<br/>';
     $message .= 'Once complete, populate the environment variable or query parameter ';
     $message .= 'mentioned at the start of this message with the key.' . '<br/>';
     

--- a/examples/cloud/gettingStartedConsole.php
+++ b/examples/cloud/gettingStartedConsole.php
@@ -71,10 +71,10 @@ if (strtolower(basename(__FILE__)) == strtolower(basename($_SERVER["SCRIPT_FILEN
                 ExampleUtils::RESOURCE_KEY_ENV_VAR . "', or configuration file." . PHP_EOL .
                 "The 51Degrees cloud service is accessed using a 'ResourceKey'. " .
                 "For more detail see " .
-                "http://51degrees.com/documentation/4.3/_info__resource_keys.html. " .
+                "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-gettingstartedconsole.php&utm_term=resource-key-required. " .
                 "A resource key with the properties required by this " .
                 "example can be created for free at " .
-                "https://configure.51degrees.com/g3gMZdPY. " .
+                "https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-gettingstartedconsole.php&utm_term=resource-key-required. " .
                 "Once complete, populated the environment variable " .
                 "mentioned at the start of this message with the key.";
             

--- a/examples/cloud/gettingStartedWeb.php
+++ b/examples/cloud/gettingStartedWeb.php
@@ -100,10 +100,10 @@ function main()
             ExampleUtils::RESOURCE_KEY_ENV_VAR . "'." . PHP_EOL .
             "The 51Degrees cloud service is accessed using a 'ResourceKey'. " .
             "For more detail see " .
-            "http://51degrees.com/documentation/4.3/_info__resource_keys.html. " .
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-gettingstartedweb.php&utm_term=resource-key-required. " .
             "A resource key with the properties required by this " .
             "example can be created for free at " .
-            "https://configure.51degrees.com/g3gMZdPY. " .
+            "https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-gettingstartedweb.php&utm_term=resource-key-required. " .
             "Once complete, populate the environment variable " .
             "mentioned at the start of this message with the key.";
 

--- a/examples/cloud/metadataConsole.php
+++ b/examples/cloud/metadataConsole.php
@@ -76,10 +76,10 @@ if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"]))
                 ExampleUtils::RESOURCE_KEY_ENV_VAR . "'." . PHP_EOL .
                 "The 51Degrees cloud service is accessed using a 'ResourceKey'. " .
                 "For more detail see " .
-                "http://51degrees.com/documentation/4.3/_info__resource_keys.html. " .
+                "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-metadataconsole.php&utm_term=resource-key-required. " .
                 "A resource key with the properties required by this " .
                 "example can be created for free at " .
-                "https://configure.51degrees.com/1QWJwHxl. " .
+                "https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-metadataconsole.php&utm_term=resource-key-required. " .
                 "Once complete, populate the environment variable " .
                 "mentioned at the start of this message with the key.";
 

--- a/examples/cloud/nativeModelLookupConsole.php
+++ b/examples/cloud/nativeModelLookupConsole.php
@@ -68,12 +68,12 @@ if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"]))
                 ExampleUtils::RESOURCE_KEY_ENV_VAR . "'." . PHP_EOL .
                 "The 51Degrees cloud service is accessed using a 'ResourceKey'. " .
                 "For more information " .
-                "see http://51degrees.com/documentation/_info__resource_keys.html. " .
+                "see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-nativemodellookupconsole.php&utm_term=resource-key-required. " .
                 "Native model lookup is not available as a free service. This means that " .
                 "you will first need a license key, which can be purchased from our " .
-                "pricing page: http://51degrees.com/pricing. Once this is done, a resource " .
+                "pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-nativemodellookupconsole.php&utm_term=resource-key-required. Once this is done, a resource " .
                 "key with the properties required by this example can be created at " .
-                "https://configure.51degrees.com/QKyYH5XT. You can now populate the " .
+                "https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-nativemodellookupconsole.php&utm_term=resource-key-required. You can now populate the " .
                 "environment variable mentioned at the start of this message with the " .
                 "resource key or pass it as the first argument on the command line.";
 

--- a/examples/cloud/tacLookupConsole.php
+++ b/examples/cloud/tacLookupConsole.php
@@ -72,12 +72,12 @@ if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"])) {
                 ExampleUtils::RESOURCE_KEY_ENV_VAR . "', or configuration file." . PHP_EOL .
                 "The 51Degrees cloud service is accessed using a 'ResourceKey'. " .
                 "For more detail see " .
-                "http://51degrees.com/documentation/_info__resource_keys.html. " .
+                "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-taclookupconsole.php&utm_term=resource-key-required. " .
                 "TAC lookup is not available as a free service. This means " .
                 "that you will first need a license key, which can be purchased " .
-                "from our pricing page: http://51degrees.com/pricing. Once this is " .
+                "from our pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-taclookupconsole.php&utm_term=resource-key-required. Once this is " .
                 "done, a resource key with the properties required by this example " .
-                "can be created at https://configure.51degrees.com/QKyYH5XT. You " .
+                "can be created at https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-taclookupconsole.php&utm_term=resource-key-required. You " .
                 "can now populate the environment variable mentioned at the start " .
                 "of this message with the resource key or pass it as the first " .
                 "argument on the command line.";

--- a/examples/cloud/userAgentClientHints-Web.php
+++ b/examples/cloud/userAgentClientHints-Web.php
@@ -35,7 +35,7 @@
  * The resource key is used as short-hand to store the particular set of
  * properties you are interested in as well as any associated license keys
  * that entitle you to increased request limits and/or paid-for properties.
- * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com).
+ * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-useragentclienthints-web.php&utm_term=header).
  * Make sure to include required User Agent Client Hints Set Header properties which are in the following format, to get full * client-hints functionality.
  * SetHeader[Component name][Response header name]
  
@@ -62,7 +62,7 @@ use fiftyone\pipeline\core\Utils;
 use fiftyone\pipeline\devicedetection\DeviceDetectionPipelineBuilder;
 use fiftyone\pipeline\devicedetection\examples\cloud\classes\ExampleUtils;
 
-// We then create a pipeline with the builder. Create your own resource key for free at https://configure.51degrees.com.
+// We then create a pipeline with the builder. Create your own resource key for free at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-useragentclienthints-web.php&utm_term=top.
 
 // Check if there is a resource key in the environment variable or query parameter
 // and use it if there is one. You will need to switch this for your own resource key.
@@ -77,7 +77,7 @@ if (empty($resourceKey)) {
     $message = 'No resource key specified in the environment variable or query parameter ';
     $message .= "'" . ExampleUtils::RESOURCE_KEY_ENV_VAR . "'." . PHP_EOL;
     $message .= 'Create a resource key with the properties required by this example';
-    $message .= 'at https://configure.51degrees.com' . '<br/>';
+    $message .= 'at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-useragentclienthints-web.php&utm_term=resource-key-required' . '<br/>';
     $message .= 'Once complete, populate the environment variable or query parameter ';
     $message .= 'mentioned at the start of this message with the key.' . '<br/>';
 
@@ -106,7 +106,7 @@ $device = $flowData->device;
 // requested. So set whatever headers are required by the browser in
 // order to return the evidence needed by the pipeline.
 // More info on this can be found at
-// https://51degrees.com/blog/user-agent-client-hints
+// https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-php&utm_content=examples-cloud-useragentclienthints-web.php&utm_term=top
 Utils::setResponseHeader($flowData);
 
 // Generate the HTML

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees PHP Device Detection
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=php-open-source "Data rewards the curious") **PHP Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=readme.md&utm_term=51degrees-php-device-detection "Data rewards the curious") **PHP Device Detection**
 
-[Developer Documentation](https://51degrees.com/device-detection-php/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=php-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-php/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=readme.md&utm_term=51degrees-php-device-detection "developer documentation")
 
 ## Introduction
 This project contains the source code for the PHP implementation of 51Degrees' 
@@ -11,14 +11,14 @@ cloud-based device detection engine for use with the
 
 ## Dependencies
 
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=readme.md&utm_term=dependencies) page shows 
 the PHP versions that we currently test against. The software may run fine against other 
 versions, but additional caution should be applied.
 
-You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=readme.md&utm_term=dependencies)
 to use the Cloud API. You can create resource keys using our 
-[configurator](https://configure.51degrees.com/), see our 
-[documentation](https://51degrees.com/documentation/_concepts__configurator.html) on how to use this.
+[configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=readme.md&utm_term=dependencies), see our 
+[documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php&utm_content=readme.md&utm_term=dependencies) on how to use this.
 
 ## Examples
 


### PR DESCRIPTION
Tag navigational 51degrees.com and configure.51degrees.com links with the standard UTM vocabulary so the Content Team can trace traffic to its exact source. Replaces the old logo scheme (Logo.ashx -> /img/logo.png), normalises http/www/protocol-relative variants to https, and un-versions stale documentation paths. Adds a UTM link lint workflow.